### PR TITLE
Reserve static internal ips for etcds and cfssl server instances

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -29,6 +29,14 @@ resource "random_string" "cfssl_suffix" {
   }
 }
 
+// reserve Ip address
+resource "google_compute_address" "cfssl_server_address" {
+  name         = "cfssl-server-address-${count.index}-${var.cluster_name}"
+  address_type = "INTERNAL"
+  subnetwork   = "${var.subnetwork_link}"
+  address      = "${var.cfssl_server_address}"
+}
+
 // Instance
 resource "google_compute_instance" "cfssl" {
   name        = "cfssl-${var.cluster_name}-${random_string.cfssl_suffix.result}"
@@ -54,7 +62,7 @@ resource "google_compute_instance" "cfssl" {
 
   network_interface {
     subnetwork = "${var.subnetwork_link}"
-    address    = "${var.cfssl_server_address}"
+    address    = "${google_compute_address.cfssl_server_address.address}"
   }
 
   tags = ["${concat(list("cfssl-${var.cluster_name}"), var.cluster_instance_tags)}"]

--- a/etcd.tf
+++ b/etcd.tf
@@ -39,6 +39,15 @@ resource "random_string" "r" {
   }
 }
 
+// reserve Ip addresses
+resource "google_compute_address" "etcd_addresses" {
+  count        = "${var.etcd_instance_count}"
+  name         = "etcd-address-${count.index}-${var.cluster_name}"
+  address_type = "INTERNAL"
+  subnetwork   = "${var.subnetwork_link}"
+  address      = "${var.etcd_addresses[count.index]}"
+}
+
 // Instances
 resource "google_compute_instance" "etcd" {
   count       = "${var.etcd_instance_count}"
@@ -65,7 +74,7 @@ resource "google_compute_instance" "etcd" {
 
   network_interface {
     subnetwork = "${var.subnetwork_link}"
-    address    = "${var.etcd_addresses[count.index]}"
+    address    = "${google_compute_address.etcd_addresses.*.address[count.index]}"
   }
 
   tags = ["${concat(list("etcd-${var.cluster_name}"), var.cluster_instance_tags)}"]


### PR DESCRIPTION
```
$ gcloud compute addresses list
NAME                            REGION        ADDRESS         STATUS
public-ingresss-k8s                           35.227.235.38   IN_USE
public-ingresss-k8s-exp-1                     35.190.79.55    IN_USE
cfssl-server-address-0-k8s      europe-west2  10.22.20.5      IN_USE
core-nat-europe-west2-a-public  europe-west2  35.189.110.205  IN_USE
core-nat-europe-west2-b-public  europe-west2  35.189.124.85   IN_USE
core-nat-europe-west2-c-public  europe-west2  35.189.80.207   IN_USE
etcd-address-0-k8s              europe-west2  10.22.20.4      IN_USE
etcd-address-1-k8s              europe-west2  10.22.20.68     IN_USE
etcd-address-2-k8s              europe-west2  10.22.20.132    IN_USE
```