### PR TITLE
rename var.coreos_image to var.container_linux_image

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -48,7 +48,7 @@ resource "google_compute_instance" "cfssl" {
 
   boot_disk {
     initialize_params {
-      image = var.coreos_image
+      image = var.container_linux_image
     }
 
     auto_delete = true

--- a/etcd.tf
+++ b/etcd.tf
@@ -64,7 +64,7 @@ resource "google_compute_instance" "etcd" {
 
   boot_disk {
     initialize_params {
-      image = var.coreos_image
+      image = var.container_linux_image
     }
 
     auto_delete = true

--- a/masters.tf
+++ b/masters.tf
@@ -48,7 +48,7 @@ resource "google_compute_instance_template" "master" {
   can_ip_forward       = true
 
   disk {
-    source_image = var.coreos_image
+    source_image = var.container_linux_image
     auto_delete  = true
     boot         = true
     disk_size_gb = "50"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 // Common
-variable "coreos_image" {
-  description = "The coreos image to use. Default to the latest from the stable channel"
+variable "container_linux_image" {
+  description = "The container linux image to use. Default to the latest from the stable channel"
   default     = "projects/coreos-cloud/global/images/family/coreos-stable"
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -23,7 +23,7 @@ resource "google_compute_instance_template" "worker" {
   can_ip_forward       = true
 
   disk {
-    source_image = var.coreos_image
+    source_image = var.container_linux_image
     auto_delete  = true
     boot         = true
     disk_size_gb = "50"


### PR DESCRIPTION
This reflects the possibility that the image could be either CoreOS or Flatcar Container Linux.