### PR TITLE
use new version block with google_compute_region_instance_group_manager

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -86,10 +86,14 @@ resource "google_compute_target_pool" "masters-pool" {
 resource "google_compute_region_instance_group_manager" "masters" {
   name               = "masters-group-manager-${var.cluster_name}"
   base_instance_name = "master-${var.cluster_name}"
-  instance_template  = google_compute_instance_template.master.self_link
   region             = var.region
   target_size        = var.master_instance_count
   target_pools       = [google_compute_target_pool.masters-pool.self_link]
+
+  version {
+    name               = "masters"
+    instance_template  = google_compute_instance_template.master.self_link
+  }
 }
 
 // Load Balancer

--- a/workers.tf
+++ b/workers.tf
@@ -57,9 +57,13 @@ resource "google_compute_instance_template" "worker" {
 resource "google_compute_region_instance_group_manager" "workers" {
   name               = "workes-group-manager-${var.cluster_name}"
   base_instance_name = "worker-${var.cluster_name}"
-  instance_template  = google_compute_instance_template.worker.self_link
   region             = var.region
   target_size        = var.worker_instance_count
+
+  version {
+    name               = "workers"
+    instance_template  = google_compute_instance_template.worker.self_link
+  }
 }
 
 // Firewall Rules


### PR DESCRIPTION
For google provider version >=3.0.0 support. Incompatible with earlier versions of the provider.