### PR TITLE
Ignore changes to boot image for etcd and cfssl

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -54,6 +54,10 @@ resource "google_compute_instance" "cfssl" {
     auto_delete = true
   }
 
+  lifecycle {
+    ignore_changes = [boot_disk.0.initialize_params.0.image]
+  }
+
   attached_disk {
     source      = google_compute_disk.cfssl-data.self_link
     mode        = "READ_WRITE"

--- a/etcd.tf
+++ b/etcd.tf
@@ -70,6 +70,10 @@ resource "google_compute_instance" "etcd" {
     auto_delete = true
   }
 
+  lifecycle {
+    ignore_changes = [boot_disk.0.initialize_params.0.image]
+  }
+
   attached_disk {
     source      = google_compute_disk.etcd-data[count.index].self_link
     mode        = "READ_WRITE"


### PR DESCRIPTION
Once the instances are launched they're updated automatically, so there's generally no need to recreate the instance if the image version is bumped.

Could be worked around with tainting.