### PR TITLE
Explicit project definition for iam resources

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -11,33 +11,39 @@ resource "google_service_account_key" "k8s-master-key" {
 
 // Let master view resources and modify routes, firewalls, and disks 
 resource "google_project_iam_member" "master-compute-viewer" {
-  role   = "roles/compute.viewer"
-  member = "serviceAccount:${google_service_account.k8s-master.email}"
+  project = var.project_id
+  role    = "roles/compute.viewer"
+  member  = "serviceAccount:${google_service_account.k8s-master.email}"
 }
 
 resource "google_project_iam_member" "master-network" {
-  role   = "roles/compute.networkAdmin"
-  member = "serviceAccount:${google_service_account.k8s-master.email}"
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:${google_service_account.k8s-master.email}"
 }
 
 resource "google_project_iam_member" "master-security" {
-  role   = "roles/compute.securityAdmin"
-  member = "serviceAccount:${google_service_account.k8s-master.email}"
+  project = var.project_id
+  role    = "roles/compute.securityAdmin"
+  member  = "serviceAccount:${google_service_account.k8s-master.email}"
 }
 
 resource "google_project_iam_member" "master-storage" {
-  role   = "roles/compute.storageAdmin"
-  member = "serviceAccount:${google_service_account.k8s-master.email}"
+  project = var.project_id
+  role    = "roles/compute.storageAdmin"
+  member  = "serviceAccount:${google_service_account.k8s-master.email}"
 }
 
 resource "google_project_iam_member" "master-instance" {
-  role   = "roles/compute.instanceAdmin.v1"
-  member = "serviceAccount:${google_service_account.k8s-master.email}"
+  project = var.project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.k8s-master.email}"
 }
 
 resource "google_project_iam_member" "master-service-account-user" {
-  role   = "roles/iam.serviceAccountUser"
-  member = "serviceAccount:${google_service_account.k8s-master.email}"
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.k8s-master.email}"
 }
 
 // Master Instances

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,8 @@
 // Common
+variable "project_id" {
+  description = "The gcp project id. Required for all google_project_iam_* resources with provider >=v4"
+}
+
 variable "container_linux_image" {
   description = "The container linux image to use. Default to the latest from the stable channel"
   default     = "projects/coreos-cloud/global/images/family/coreos-stable"

--- a/workers.tf
+++ b/workers.tf
@@ -11,8 +11,9 @@ resource "google_service_account_key" "k8s-worker-key" {
 
 // Allow workers to view all resources but not modify
 resource "google_project_iam_member" "worker-icompute-viewer" {
-  role   = "roles/compute.viewer"
-  member = "serviceAccount:${google_service_account.k8s-worker.email}"
+  project = var.project_id
+  role    = "roles/compute.viewer"
+  member  = "serviceAccount:${google_service_account.k8s-worker.email}"
 }
 
 // Worker Instances


### PR DESCRIPTION
When upgrading to terraform provider v4.0, project needs to be explicitly
defined for all google_project_iam_* resources:
https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_4_upgrade#resource-google_project_iam