### PR TITLE
Use proactive updates to refresh nodes user-data

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -97,8 +97,9 @@ resource "google_compute_region_instance_group_manager" "masters" {
   target_pools       = [google_compute_target_pool.masters-pool.self_link]
 
   update_policy {
-    type           = "OPPORTUNISTIC"
-    minimal_action = "REPLACE"
+    type                           = "PROACTIVE"
+    minimal_action                 = "REFRESH"
+    most_disruptive_allowed_action = "REFRESH"
   }
 
   version {

--- a/workers.tf
+++ b/workers.tf
@@ -62,8 +62,9 @@ resource "google_compute_region_instance_group_manager" "workers" {
   target_size        = var.worker_instance_count
 
   update_policy {
-    type           = "OPPORTUNISTIC"
-    minimal_action = "REPLACE"
+    type                           = "PROACTIVE"
+    minimal_action                 = "REFRESH"
+    most_disruptive_allowed_action = "REFRESH"
   }
 
   version {


### PR DESCRIPTION
Allow instance groups to proactively update nodes in "REFRESH" mode only. That will mean that group managers can only attempt nodes' config in place and not start/stop instances. Since we are allowed to patch user-data that way we can use a daemon like kured to roll ignition updates to the cluster.